### PR TITLE
Remove reference to dead link

### DIFF
--- a/source/ref/templates/builtins.rst
+++ b/source/ref/templates/builtins.rst
@@ -2026,7 +2026,7 @@ individual elements of the sequence.
 Returns a slice of the list.
 
 Uses the same syntax as Python's list slicing. See
-http://www.diveintopython3.net/native-datatypes.html#slicinglists
+https://www.cmi.ac.in/~madhavan/courses/prog2-2012/docs/diveintopython3/native-datatypes.html#slicinglists
 for an introduction.
 
 Example::


### PR DESCRIPTION
Dive Into Python is no longer available at diveintopython.org. Updating the file to a working link.